### PR TITLE
Fix local replica canisters in Node.js environment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 19.x]
+        node-version: [14.x, 16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [14.x, 16.x, 19.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ic0",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ic0",
-            "version": "0.2.2",
+            "version": "0.2.3",
             "license": "Apache-2.0",
             "dependencies": {
                 "@dfinity/agent": "^0.15.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ic0",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "description": "An easy-to-use JavaScript API for the Internet Computer.",
     "author": "DFINITY Foundation",
     "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { deferredReplica, replica } from './replica';
 import { Canister, Network, Replica } from './types';
 
 const ic = deferredReplica('https://ic0.app');
-const local = deferredReplica('http://localhost:4943');
+const local = deferredReplica('http://localhost:4943', { local: true });
 
 // Configure exports for TS, CommonJS, and ESM
 const defaultExport = ic;

--- a/src/replica.ts
+++ b/src/replica.ts
@@ -8,6 +8,7 @@ export type AgentReplica = Replica<ReturnType<typeof agentCanister>>;
 // Define an IC replica from the given hostname (e.g. `https://ic0.app`)
 export const replica = (
     host?: string | HttpAgent | undefined,
+    options: { local?: boolean } = {},
 ): AgentReplica => {
     let agent: HttpAgent;
     if (!host) {
@@ -22,7 +23,7 @@ export const replica = (
         );
     }
     // Fetch root key for local replica
-    if (agent.isLocal()) {
+    if (options.local) {
         agent.fetchRootKey().catch((err) => {
             console.warn(
                 'Unable to fetch root key (check to ensure that your local replica is running)',


### PR DESCRIPTION
Partially resolves #1 by always using the mainnet Candid UI when generating JS bindings for a local canister's Candid interface. 
