### PR TITLE
Add more top-level exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ic0",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ic0",
-            "version": "0.2.3",
+            "version": "0.2.4",
             "license": "Apache-2.0",
             "dependencies": {
                 "@dfinity/agent": "^0.15.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ic0",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "description": "An easy-to-use JavaScript API for the Internet Computer.",
     "author": "DFINITY Foundation",
     "license": "Apache-2.0",

--- a/src/canister/agentCanister.ts
+++ b/src/canister/agentCanister.ts
@@ -5,7 +5,7 @@ import { Canister } from '../types';
 
 const didJsCache = new Map<string, string>();
 
-class AgentCanister implements Canister {
+export class AgentCanister implements Canister {
     public readonly agent: HttpAgent;
     public readonly id: string;
 

--- a/src/canister/devCanister.ts
+++ b/src/canister/devCanister.ts
@@ -1,6 +1,6 @@
 import { Canister } from '../types';
 
-class DevCanister implements Canister {
+export class DevCanister implements Canister {
     public readonly alias: string;
     public readonly host: string;
 

--- a/src/canister/mockCanister.ts
+++ b/src/canister/mockCanister.ts
@@ -1,8 +1,8 @@
 import { Canister } from '../types';
 
-type Mocks = Record<string, (...args: any[]) => Promise<any>>;
+export type Mocks = Record<string, (...args: any[]) => Promise<any>>;
 
-class MockCanister implements Canister {
+export class MockCanister implements Canister {
     public readonly mocks: Mocks;
     public readonly fallback: Canister | undefined;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
-import { devCanister } from './canister/devCanister';
-import { mockCanister } from './canister/mockCanister';
+import { devCanister, DevCanister } from './canister/devCanister';
+import { mockCanister, MockCanister, Mocks } from './canister/mockCanister';
 import { deferredReplica, replica } from './replica';
 import { Canister, Network, Replica } from './types';
+import { HttpAgent } from '@dfinity/agent';
+import { agentCanister, AgentCanister } from './canister/agentCanister';
 
 const ic = deferredReplica('https://ic0.app');
 const local = deferredReplica('http://localhost:4943', { local: true });
@@ -13,11 +15,29 @@ Object.assign(defaultExport, {
     ic,
     local,
     replica,
+    agentCanister,
     devCanister,
     mockCanister,
+    HttpAgent,
     __esModule: true, // Recognize as ES Module
 });
 module.exports = defaultExport;
 export default defaultExport;
-export { ic, local, replica, devCanister, mockCanister };
-export type { Canister, Network, Replica };
+export {
+    ic,
+    local,
+    replica,
+    agentCanister,
+    devCanister,
+    mockCanister,
+    HttpAgent,
+};
+export type {
+    Canister,
+    Network,
+    Replica,
+    AgentCanister,
+    DevCanister,
+    MockCanister,
+    Mocks,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
+import { HttpAgent } from '@dfinity/agent';
+import { agentCanister, AgentCanister } from './canister/agentCanister';
 import { devCanister, DevCanister } from './canister/devCanister';
 import { mockCanister, MockCanister, Mocks } from './canister/mockCanister';
 import { deferredReplica, replica } from './replica';
 import { Canister, Network, Replica } from './types';
-import { HttpAgent } from '@dfinity/agent';
-import { agentCanister, AgentCanister } from './canister/agentCanister';
 
 const ic = deferredReplica('https://ic0.app');
 const local = deferredReplica('http://localhost:4943', { local: true });
@@ -41,3 +41,4 @@ export type {
     MockCanister,
     Mocks,
 };
+

--- a/src/replica.ts
+++ b/src/replica.ts
@@ -1,9 +1,9 @@
 import { HttpAgent } from '@dfinity/agent';
 import fetch from 'cross-fetch';
-import { agentCanister } from './canister/agentCanister';
+import { agentCanister, AgentCanister } from './canister/agentCanister';
 import { Replica } from './types';
 
-export type AgentReplica = Replica<ReturnType<typeof agentCanister>>;
+export type AgentReplica = Replica<AgentCanister>;
 
 // Define an IC replica from the given hostname (e.g. `https://ic0.app`)
 export const replica = (


### PR DESCRIPTION
Re-exports `HttpAgent` and implementation-specific canister types from the top-level module. 