### PR TITLE
Use `https://icp-api.io` in place of `https://ic0.app`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ic0",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "ic0",
-            "version": "0.2.6",
+            "version": "0.2.7",
             "license": "Apache-2.0",
             "dependencies": {
                 "@dfinity/agent": "^0.15.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ic0",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "description": "An easy-to-use JavaScript API for the Internet Computer.",
     "author": "DFINITY Foundation",
     "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { mockCanister, MockCanister, Mocks } from './canister/mockCanister';
 import { deferredReplica, replica } from './replica';
 import { Canister, Network, Replica } from './types';
 
-const ic = deferredReplica('https://ic0.app');
+const ic = deferredReplica('https://icp-api.io');
 const local = deferredReplica('http://localhost:4943', { local: true });
 
 // Configure exports for TS, CommonJS, and ESM


### PR DESCRIPTION
[Context](https://forum.dfinity.org/t/important-community-update-on-ic0-app-domain-being-flagged-by-an-anti-spam-blocklist/18537)